### PR TITLE
added command to check that git username and email were assigned

### DIFF
--- a/prework/mac/3_git.md
+++ b/prework/mac/3_git.md
@@ -30,6 +30,19 @@ git config --global user.name 'YOUR FULL NAME'
 git config --global user.email 'YOUR EMAIL ADDRESS'
 ```
 
+The terminal does not send success messages, in order to double check that you have successfully assigned your username and email: 
+
+```
+git config --list
+```
+
+Your terminal should output the following lines:
+
+```
+user.email='YOUR EMAIL ADDRESS'
+user.name='YOUR FULL NAME'
+```
+
 ### Congratulations!
 
 Time for a frosty beverage. :beers:

--- a/prework/ubuntu/4_git.md
+++ b/prework/ubuntu/4_git.md
@@ -33,6 +33,19 @@ git config --global user.name 'YOUR FULL NAME'
 git config --global user.email 'YOUR EMAIL ADDRESS'
 ```
 
+The terminal does not send success messages, in order to double check that you have successfully assigned your username and email: 
+
+```
+git config --list
+```
+
+Your terminal should output the following lines:
+
+```
+user.email='YOUR EMAIL ADDRESS'
+user.name='YOUR FULL NAME'
+```
+
 Next, run this command to download and install some awesome colors and handy aliases for Git.
 
 ```

--- a/prework/windows/3_git.md
+++ b/prework/windows/3_git.md
@@ -27,6 +27,20 @@ git config --global user.name 'YOUR FULL NAME'
 git config --global user.email 'YOUR EMAIL ADDRESS'
 ```
 
+The terminal does not send success messages, in order to double check that you have successfully assigned your username and email: 
+
+```
+git config --list
+```
+
+Your terminal should output the following lines:
+
+```
+user.email='YOUR EMAIL ADDRESS'
+user.name='YOUR FULL NAME'
+```
+
+
 ### Congratulations!
 
 Time for a frosty beverage. :beers:


### PR DESCRIPTION
Hi guys,

I had a lot of students asking me this morning how to check that the git username and email were properly assigned in terminal. I have included the git config --list command that should output the username and email that got assigned in the previous command.

I have only tested this command on a mac, but it appears to be universally used for all three os'.

Thanks,
Clare